### PR TITLE
Fix rating update form

### DIFF
--- a/feer_club/feer/templates/feer/rating_update_form.html
+++ b/feer_club/feer/templates/feer/rating_update_form.html
@@ -1,0 +1,22 @@
+{% extends "feer/base.html" %}
+{% load bootstrap3 %}
+{% bootstrap_messages %}
+
+{% block content %}
+<form action="" method="post">
+  {% csrf_token %}
+  <div class="form-group">
+    <label class="control-label" for="id_beer">Beer</label>
+    <p id="id_beer">{{ rating.beer.name }}</p>
+  </div>
+  <div class="form-group">
+    <label class="control-label" for="id_comment">Comment</label>
+    <textarea class="form-control" cols="40" id="id_comment" name="comment" placeholder="Comment" rows="10" title="">{{ rating.comment }}</textarea>
+  </div>
+  {% buttons %}
+  <button type="submit" class="btn btn-primary">
+    Submit
+  </button>
+  {% endbuttons %}
+</form>
+{% endblock content %}

--- a/feer_club/feer/views.py
+++ b/feer_club/feer/views.py
@@ -99,6 +99,7 @@ class RatingCreate(LoginRequiredMixin, CreateView):
 
 class RatingUpdate(LoginRequiredMixin, UpdateView):
     model = Rating
+    template_name_suffix = '_update_form'
     fields = ['comment']
     success_url = reverse_lazy('my_ratings')
     login_url = reverse_lazy('login')


### PR DESCRIPTION
Makes the beer type uneditable (it is fair to assume that usual behaviour is to change the comment rather than the beer). Also sets the comment text to the comment. Fixes #21 
