### PR TITLE
Added link to MobilePay

### DIFF
--- a/feer_club/feer/templates/feer/order_detail.html
+++ b/feer_club/feer/templates/feer/order_detail.html
@@ -17,7 +17,7 @@
   {% for p, c in costs %}
     <tr>
       <td>{{ p }}</td>
-      <td>{{ c }}</td>
+      <td>{{ c }} (Pay with <a href="http://mobilepay.dk/js_css/mobilepay2/App-Integration/open.html?phone=004528302813&amount={{ str(c) }}&comment={{ order.name.replace(' ', '%20') }}&lock=1">MobilePay</a>)</td>
     </tr>
   {% endfor %}
   </table>

--- a/feer_club/feer/templates/feer/order_detail.html
+++ b/feer_club/feer/templates/feer/order_detail.html
@@ -17,7 +17,7 @@
   {% for p, c in costs %}
     <tr>
       <td>{{ p }}</td>
-      <td>{{ c }} (Pay with <a href="http://mobilepay.dk/js_css/mobilepay2/App-Integration/open.html?phone=004528302813&amount={{ str(c) }}&comment={{ order.name.replace(' ', '%20') }}&lock=1">MobilePay</a>)</td>
+      <td>{{ c }} (Pay with <a href="http://mobilepay.dk/js_css/mobilepay2/App-Integration/open.html?phone=004528302813&amount={{ c }}&comment={{ order.name }}&lock=1">MobilePay</a>)</td>
     </tr>
   {% endfor %}
   </table>

--- a/feer_club/feer/templates/feer/order_detail.html
+++ b/feer_club/feer/templates/feer/order_detail.html
@@ -18,7 +18,7 @@
     <tr>
       <td>{{ p }}</td>
       <td>{{ c }} 
-      {% if user|stringformat:"s" == p %}
+      {% if not order.updatable and user|stringformat:"s" == p %}
       (Pay with <a href="http://mobilepay.dk/js_css/mobilepay2/App-Integration/open.html?phone=004528302813&amount={{ c }}&comment={{ order.name }}%20from%20{{ p }}&lock=1">MobilePay</a>)
       {% endif %}
       </td>

--- a/feer_club/feer/templates/feer/order_detail.html
+++ b/feer_club/feer/templates/feer/order_detail.html
@@ -17,7 +17,11 @@
   {% for p, c in costs %}
     <tr>
       <td>{{ p }}</td>
-      <td>{{ c }} (Pay with <a href="http://mobilepay.dk/js_css/mobilepay2/App-Integration/open.html?phone=004528302813&amount={{ c }}&comment={{ order.name }}&lock=1">MobilePay</a>)</td>
+      <td>{{ c }} 
+      {% if user|stringformat:"s" == p %}
+      (Pay with <a href="http://mobilepay.dk/js_css/mobilepay2/App-Integration/open.html?phone=004528302813&amount={{ c }}&comment={{ order.name }}%20from%20{{ p }}&lock=1">MobilePay</a>)
+      {% endif %}
+      </td>
     </tr>
   {% endfor %}
   </table>


### PR DESCRIPTION
In order details view, next to the price for each participant a link to mobilepay is added, where users only need to scan QR code and confirm in MobilePay app.